### PR TITLE
docs: schema 双入口初始化指引改为按运行时落盘（单文件即合法）

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ SKILL.md 是 Skill 的核心配置，定义了：
 
 1. 告知你的知识库有哪些领域（如"读书笔记"、"AI"、"投资"）
 2. 使用 `references/schema.md` 模板生成项目专属的 CLAUDE.md
+   > Codex / 其他 agent 用户把文件名换成 `AGENTS.md` 即可，规则相同。
 3. 创建 `raw/` 和 `wiki/` 目录结构
 4. 创建空的 `index.md` 和 `log.md`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,7 +21,7 @@ description: "LLM Wiki 模式：用 LLM 持续维护 Obsidian 知识库（raw/wi
 
 1. **声明双入口字节契约**（两文件内容完全相同，典型如 Lester 知识库）：两份文件必须字节一致；结构变更时**同一次编辑同步两个文件**，并验证 SHA-256 相等；运行时只应用与当前运行时匹配的适配章节（Claude Code 侧用 Claude Code 适配章节）。这是项目契约，不是建议。
 2. **未声明契约且两文件冲突**：Claude Code 侧以 `CLAUDE.md` 为准，并在结果中记录任务相关的冲突，提示用户裁定。
-3. **仅存在一个 schema 文件**：直接使用之。
+3. **仅存在一个 schema 文件**：直接使用之（Claude Code 单文件通常是 `CLAUDE.md`，Codex 单文件通常是 `AGENTS.md`，均为合法配置）。
 
 > 所有路径、领域、frontmatter 规范从 schema 读取，**不硬编码**。发现双入口契约下两文件不一致时，必须报告，不擅自改写。
 
@@ -69,7 +69,7 @@ description: "LLM Wiki 模式：用 LLM 持续维护 Obsidian 知识库（raw/wi
 使用前，项目根目录必须有 schema 文件（`AGENTS.md` 或 `CLAUDE.md`，推荐双入口）。如果不存在，引导用户初始化：
 
 1. 询问用户的知识库有哪些领域（如"读书笔记"、"AI"、"投资"）
-2. 使用 [references/schema.md](references/schema.md) 作为模板，生成项目专属的 `AGENTS.md`（如需 Claude Code 兼容，把完全相同的内容另存为 `CLAUDE.md`，并保留双入口契约）
+2. 使用 [references/schema.md](references/schema.md) 作为模板，按你用的运行时落盘 schema：Claude Code 生成 `CLAUDE.md`，Codex / 其他 agent 生成 `AGENTS.md`；多运行时并存则两份都存（字节完全相同，保留双入口契约）。单文件即合法配置，不强制双入口。
 3. 创建 `raw/` 和 `wiki/` 目录结构
 4. 创建空的 `index.md` 和 `log.md`
 5. 在 Obsidian 设置中将 `attachmentFolderPath` 设为 `raw`（新图片暂存 raw/ 根目录，ingest 时按领域整理到对应子目录）

--- a/references/schema.md
+++ b/references/schema.md
@@ -214,8 +214,8 @@ Schema 或索引已经正确时记录“已检查，无需更新”，不要为�
 1. 扫描 Vault 的实际 `raw/`、`wiki/` 目录；
 2. 按稳定层级策略填写模板，不登记内容叶子；
 3. 填写领域注册表，不复制其他 Vault 的领域或数量；
-4. 保存为 Vault 根目录的 `AGENTS.md`；
-5. 如需 Claude Code 兼容，把完全相同的内容保存为 `CLAUDE.md`；
+4. 按你用的运行时保存到 Vault 根目录：Claude Code → `CLAUDE.md`；Codex / 其他 agent → `AGENTS.md`；
+5. 多运行时并存则两份都存（完全相同）；单运行时单文件即合法配置；
 6. 同时保留 Codex 与 Claude Code 适配章节；
 7. 创建或检查 `index.md`、`log.md`；
 8. 计算三个权威变量和三个健康变量，写入统一索引模板；


### PR DESCRIPTION
## 背景
`edf78be`（全量演进 + 运行时与网关适配）已通过 PR #2 合入 main。本 PR 在此基础上对齐 schema 双入口的初始化措辞。

## 改动（仅 3 个说明文档）
把初始化文档从 "AGENTS.md 为主、CLAUDE.md 仅 Claude Code 兼容才加" 改为 "按运行时落盘，单文件即合法，不强制双入口"：
- `SKILL.md` 三情形 case 3 补运行时映射（Claude Code→CLAUDE.md，Codex→AGENTS.md，均为合法配置）
- `SKILL.md`、`references/schema.md` 初始化步骤改为按运行时落盘
- `README.md` quickstart 补跨运行时提示，统一三份文档口径（此前 README=CLAUDE 主、SKILL/schema=AGENTS 主，存在漂移）

## 说明
- 运行时 / lint 逻辑不变：三情形 case 3 与所有 SHA-256 校验本就是条件式，"只有 CLAUDE.md" 单文件场景已被正确支持。
- 仅改 3 个说明文档；本地编辑器/Agent 配置（.claude/、.vscode/）按 .gitignore 不入库。