### PR TITLE
feat: 六变量精校固化为固定脚本 references/index_stat.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ claude mcp add -s user zai-mcp-server --env Z_AI_API_KEY=YOUR_API_KEY -- npx -y 
 |---|---|
 | `/obsidian-llm-wiki ingest <来源>` | 处理 raw/ 中的新资料，集成到 wiki。可能更新 10-15 个相关页面 |
 | `/obsidian-llm-wiki query <问题>` | 使用 wiki 回答问题，综合多个页面并引用来源 |
-| `/obsidian-llm-wiki lint` | 健康检查：矛盾、孤立页面、缺失引用、过期内容；同时校验 `index.md` 顶部维护块、底部三变量统计行与索引健康行的同步契约（六变量精校 + 双入口 schema 字节一致） |
+| `/obsidian-llm-wiki lint` | 健康检查：矛盾、孤立页面、缺失引用、过期内容；同时校验 `index.md` 顶部维护块、底部三变量统计行与索引健康行的同步契约（六变量精校用 Skill 自带 `references/index_stat.py` + 双入口 schema 字节一致） |
 | `/obsidian-llm-wiki migrate` | 一次性迁移：将已有笔记迁移到 LLM Wiki 模式 |
 | `/obsidian-llm-wiki index` | 从当前 wiki 状态**全量重建** `index.md`，按三权威变量 + 三健康变量 + 索引健康行刷新。增量更新由 ingest/optimize/extract-thinking-frameworks/migrate/delete 触发；本命令只做全量重建。详见 SKILL.md `## Index Metadata And Statistics` |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -378,11 +378,16 @@ _统计：{indexed_page_count} 个已索引页面 | {wiki_file_count} 个 Wiki �
 
 **机检**：
 - **快校（lint 用，上限预警）**：保留旧 awk 一行版，重命名为 "raw entry count"（仅数 `| [[` 候选行，不去重、不解析），作为漂移预警的快检上限——**不是** `indexed_page_count` 的精确值。
-- **精校（所有写命令用）**：扫 `wiki/**/*.md` 建 `{stem: path}` 字典 → 解析 index 数据行 title → 命中（dedupe by path，记 `indexed_page_count`）/ 未命中（`broken_count`）/ 字典中未被命中（`missing_count`）/ 同 path 重复（`duplicate_count`）；`wiki_file_count` = 字典 size；`registered_domain_count` = schema 注册表数据行数。
+- **精校（所有写命令用）**：**直接运行 Skill 自带固定脚本 [references/index_stat.py](references/index_stat.py)**，不要每次临时新写脚本。脚本实现与本条口径一致：扫 `wiki/**/*.md` 建 `{stem: path}` 字典 → 解析 index 数据行 title → 命中（dedupe by path，记 `indexed_page_count`）/ 未命中或歧义（`broken_count`）/ 字典中未被命中（`missing_count`）/ 同 path 重复（`duplicate_count`）；`wiki_file_count` = 字典 size；`registered_domain_count` = schema 注册表数据行数。脚本额外输出未收录/断链/重复明细、双入口注册表行数对照、**页脚旧值 vs 扫描值漂移报告**（供『统计漂移修正』，`footer_match=true` 即页脚无漂移）；`--json` 为机读模式。脚本不可用时按本条算法降级手工执行。
 
 ```bash
 # 快校 awk 一行版（raw entry count 上限，非精确 indexed_page_count）
 awk '/^\| 页面 \| 摘要 \| 标签 \|/{t=1;next} t==1 && /^\|---/{t=2;next} t==2 && /^\| \[\[/ {c++} t==2 && /^## /{t=0} END{print c+0}' index.md
+
+# 精校固定脚本：<skill_base> 为本 Skill 基目录（Skill 加载时给定），<vault> 为知识库根目录；
+# Python 按 §文档预处理与运行环境 优先级取（项目 .venv 首选）；输出六变量 + 明细 + 页脚漂移对照
+"<python>" "<skill_base>/references/index_stat.py" "<vault>"           # 人类可读
+"<python>" "<skill_base>/references/index_stat.py" "<vault>" --json    # 机读
 ```
 
 **排除项**（不计入页面数）：`.canvas` 文件、图片、附件、`raw/...` 源链接、生成产物、外部链接、schema 文件、`[[页面标题]]` 这类示例占位、`templates/` 与 `assets/` 下的模板。
@@ -416,7 +421,7 @@ missing_count / broken_count / duplicate_count ==  当次扫描结果
 5. 顶部维护块 + 底部统计行 + 索引健康行 **同一次编辑**同步替换（三处日期字面一致）
 6. 若涉及双入口 schema 变更（如新领域），同步编辑 `AGENTS.md` + `CLAUDE.md` + 验 SHA-256
 7. `log.md` 追加一条最终记录（含 `AGENTS.md` / `CLAUDE.md` / `index.md` / frontmatter 四项 + 六变量 + `indexed_page_count` 变化/不变/漂移修正 标识）
-8. 写后自检（快校 awk + 精校；统计行与健康行各只出现 1 次）
+8. 写后自检（快校 awk + 精校固定脚本 [references/index_stat.py](references/index_stat.py)；统计行与健康行各只出现 1 次）
 
 **增量 vs 全量分工**：
 
@@ -447,7 +452,7 @@ missing_count / broken_count / duplicate_count ==  当次扫描结果
 4. **索引健康行**字面合规（正则）：`^> 索引健康：未收录 (\d+) \| Markdown 断链 (\d+) \| 重复条目 (\d+)；.+。$`。
 5. 顶部日期 = 底部统计行日期 = 今天。
 6. **快校**：awk 数候选行数 ≥ `indexed_page_count`（上限校验）。
-7. **精校**：按 §六变量计数口径 扫描得六变量；分别与统计行三数 + 健康行三数核对。
+7. **精校**：运行 [references/index_stat.py](references/index_stat.py)（或按 §六变量计数口径 手工扫描）得六变量；分别与统计行三数 + 健康行三数核对（脚本自带页脚对照与漂移报告）。
 8. 校验统计行与索引健康行**各只出现 1 次**（grep 计数 = 1）。
 9. 校验每个 `## <领域>` 章节下有且仅有一张表，表头/分隔行/数据行格式合规。
 10. 校验同一章节内数据行不重复（按 `[[<页面标题>]]` 去重）。

--- a/references/index_stat.py
+++ b/references/index_stat.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""obsidian-llm-wiki 精校脚本：index.md 六变量统计验证（固定 reference 脚本）.
+
+口径来源：SKILL.md §Index Metadata And Statistics（六变量计数口径 · 机检 · 精校）。
+
+  - wiki_file_count         实际 wiki/**/*.md 文件数（排除 index.md / log.md / *.canvas / templates/ / assets/）
+  - registered_domain_count schema『领域注册表』数据行数（CLAUDE.md 优先，AGENTS.md 对照）
+  - indexed_page_count      index 数据行 [[title]] 可解析到唯一 wiki 文件、按 path 去重后的条目数
+  - broken_count            无法唯一解析且不属于排除项的 index 链接（未命中 / 歧义）
+  - missing_count           有 wiki 文件但无索引条目覆盖
+  - duplicate_count         同一 wiki 页面重复出现的额外条目数（出现数 − 1）
+
+排除项：.canvas / 图片 / 附件扩展名、raw/... 源链接、代码块与行内代码中的示例占位链接。
+
+用法：
+  python index_stat.py <vault_root> [--json]
+
+示例（项目 .venv 优先，见 SKILL.md §文档预处理与运行环境）：
+  .venv\\Scripts\\python.exe "<skill_base>/references/index_stat.py" "D:/path/to/vault"
+
+输出：六变量 + 未收录/断链/重复明细 + 页脚旧值对照（漂移报告）。--json 输出机读结构。
+退出码：0 = 正常完成（无论是否有缺口）；2 = 用法/路径错误。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):  # Windows 控制台默认 GBK，强制 UTF-8
+    sys.stdout.reconfigure(encoding="utf-8")
+
+# 排除项（Schema §Index 六变量计数口径 · 排除项）
+ATTACH_EXT = (
+    ".canvas", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".pdf",
+    ".excalidraw", ".mp4", ".mov", ".mdx",
+)
+EXCLUDED_NAMES = {"index.md", "log.md"}
+EXCLUDED_PARTS = {"templates", "assets"}
+
+FOOT_STAT = re.compile(
+    r"_统计：(\d+) 个已索引页面 \| (\d+) 个 Wiki 文件 \| (\d+) 个注册领域 "
+    r"\| 上次更新于 (\d{4}-\d{2}-\d{2})_"
+)
+FOOT_HEALTH = re.compile(
+    r"> 索引健康：未收录 (\d+) \| Markdown 断链 (\d+) \| 重复条目 (\d+)"
+)
+
+
+def scan_wiki(vault: Path) -> list[str]:
+    """枚举 wiki/**/*.md（posix 相对路径），按口径排除非页面文件。"""
+    files: list[str] = []
+    wiki = vault / "wiki"
+    if not wiki.is_dir():
+        return files
+    for p in sorted(wiki.rglob("*.md")):
+        if p.name.lower() in EXCLUDED_NAMES:
+            continue
+        if any(part in EXCLUDED_PARTS for part in p.parts[:-1]):
+            continue
+        files.append(p.relative_to(vault).as_posix())
+    return files
+
+
+def count_registered_domains(vault: Path) -> tuple[int | None, list[str]]:
+    """读 schema『领域注册表』数据行数；CLAUDE.md 优先，AGENTS.md 存在时对照行数。"""
+    def table_rows(schema: Path) -> int | None:
+        text = schema.read_text(encoding="utf-8")
+        m = re.search(r"^#{1,3}\s*.*领域注册表.*$", text, flags=re.M)
+        if not m:
+            return None
+        block: list[str] = []
+        for line in text[m.end():].splitlines():
+            if line.lstrip().startswith("|"):
+                block.append(line.strip())
+            elif block:
+                break
+        rows = [r for r in block[1:] if not re.fullmatch(r"\|[\s:|-]+\|?", r)]
+        return len(rows)
+
+    notes: list[str] = []
+    primary = vault / "CLAUDE.md"
+    secondary = vault / "AGENTS.md"
+    count: int | None = None
+    if primary.is_file():
+        count = table_rows(primary)
+        if count is None:
+            notes.append("CLAUDE.md: 未找到『领域注册表』表格")
+    if secondary.is_file():
+        c2 = table_rows(secondary)
+        if count is not None and c2 is not None and c2 != count:
+            notes.append(f"双入口注册表行数不一致：CLAUDE.md={count}, AGENTS.md={c2}（须先同步再计数）")
+        elif count is None and c2 is not None:
+            count = c2
+            notes.append(f"registered_domain_count 取自 AGENTS.md（{c2}）")
+    if count is None and not notes:
+        notes.append("vault 根未找到 CLAUDE.md / AGENTS.md 或其『领域注册表』")
+    return count, notes
+
+
+def extract_targets(vault: Path) -> list[str]:
+    """抽取 index.md 全部 [[target]]（去 alias/锚点），剔除代码块与行内代码中的示例占位。"""
+    index = vault / "index.md"
+    text = index.read_text(encoding="utf-8")
+    no_code = re.sub(r"```.*?```", "", text, flags=re.S)
+    no_code = re.sub(r"`[^`\n]*`", "", no_code)
+    targets: list[str] = []
+    for t in re.findall(r"\[\[([^\]]+)\]\]", no_code):
+        t = t.split("|")[0].split("#")[0].strip()
+        if t:
+            targets.append(t)
+    return targets
+
+
+def resolve(targets: list[str], wiki_files: list[str]):
+    """按精校口径解析：返回 (resolved 页面集, 断链/歧义明细, path 出现计数)。"""
+    by_stem: dict[str, list[str]] = {}
+    for f in wiki_files:
+        by_stem.setdefault(Path(f).stem, []).append(f)
+
+    resolved: set[str] = set()
+    broken: list[tuple[str, str]] = []
+    seen: Counter[str] = Counter()
+    for t in targets:
+        if t.startswith("raw/") or t.lower().endswith(ATTACH_EXT):
+            continue  # 排除项不计入
+        hits = {f for f in wiki_files if f == t or f == "wiki/" + t or f.endswith("/" + t)}
+        stem_hits = by_stem.get(t, [])
+        if len(hits) == 1:
+            page = next(iter(hits))
+        elif len(hits) > 1:
+            broken.append((t, "歧义: " + " | ".join(sorted(hits))))
+            continue
+        elif len(stem_hits) == 1:
+            page = stem_hits[0]
+        elif len(stem_hits) > 1:
+            broken.append((t, "歧义: " + " | ".join(stem_hits)))
+            continue
+        else:
+            broken.append((t, "未命中"))
+            continue
+        seen[page] += 1
+        resolved.add(page)
+    return resolved, broken, seen
+
+
+def read_footer(vault: Path) -> dict[str, int] | None:
+    """解析 index.md 页脚旧六变量（供漂移对照）。"""
+    text = (vault / "index.md").read_text(encoding="utf-8")
+    ms, mh = FOOT_STAT.search(text), FOOT_HEALTH.search(text)
+    if not ms or not mh:
+        return None
+    return {
+        "indexed_page_count": int(ms.group(1)),
+        "wiki_file_count": int(ms.group(2)),
+        "registered_domain_count": int(ms.group(3)),
+        "missing_count": int(mh.group(1)),
+        "broken_count": int(mh.group(2)),
+        "duplicate_count": int(mh.group(3)),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="obsidian-llm-wiki 六变量精校")
+    ap.add_argument("vault_root", help="vault 根目录（含 index.md 与 wiki/）")
+    ap.add_argument("--json", action="store_true", help="输出 JSON（机读）")
+    args = ap.parse_args()
+
+    vault = Path(args.vault_root)
+    if not vault.is_dir():
+        print(f"错误：vault 根不存在：{vault}", file=sys.stderr)
+        return 2
+    if not (vault / "index.md").is_file():
+        print(f"错误：{vault / 'index.md'} 不存在", file=sys.stderr)
+        return 2
+
+    wiki_files = scan_wiki(vault)
+    domains, domain_notes = count_registered_domains(vault)
+    targets = extract_targets(vault)
+    resolved, broken, seen = resolve(targets, wiki_files)
+
+    missing = [f for f in wiki_files if f not in resolved]
+    duplicates = {p: c for p, c in seen.items() if c > 1}
+    result = {
+        "indexed_page_count": len(resolved),
+        "wiki_file_count": len(wiki_files),
+        "registered_domain_count": domains,
+        "missing_count": len(missing),
+        "broken_count": len(broken),
+        "duplicate_count": sum(c - 1 for c in duplicates.values()),
+    }
+
+    footer = read_footer(vault)
+    drift = None
+    if footer:
+        drift = {k: {"footer": footer[k], "scan": result[k]}
+                 for k in result if footer[k] != result[k]}
+    footer_match = footer is not None and not drift
+
+    payload = {
+        "vault": str(vault),
+        **result,
+        "missing": missing,
+        "broken": [{"target": t, "reason": r} for t, r in broken],
+        "duplicates": duplicates,
+        "domain_notes": domain_notes,
+        "footer": footer,
+        "footer_match": footer_match,
+        "drift": drift,
+    }
+
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    six = (f"{result['indexed_page_count']}/{result['wiki_file_count']}/"
+           f"{result['registered_domain_count']}")
+    health = f"{result['missing_count']}/{result['broken_count']}/{result['duplicate_count']}"
+    print(f"== obsidian-llm-wiki 精校（references/index_stat.py）==")
+    print(f"vault: {vault}")
+    print(f"wiki_file_count:         {result['wiki_file_count']}")
+    print(f"indexed_page_count:      {result['indexed_page_count']}")
+    print(f"registered_domain_count: {result['registered_domain_count']}")
+    print(f"missing_count:           {result['missing_count']}")
+    print(f"broken_count:            {result['broken_count']}")
+    print(f"duplicate_count:         {result['duplicate_count']}")
+    for m in missing:
+        print(f"  MISSING: {m}")
+    for t, r in broken:
+        print(f"  BROKEN:  {t} ({r})")
+    for p, c in duplicates.items():
+        print(f"  DUP:     {p} ×{c}")
+    for n in domain_notes:
+        print(f"  NOTE:    {n}")
+    if footer is None:
+        print("页脚对照: 未找到统计行/索引健康行（页脚格式异常）")
+    elif footer_match:
+        print(f"页脚对照: 一致（六变量 {six} | {health}）")
+    else:
+        print(f"页脚对照: 漂移！扫描值 {six} | {health}，页脚旧值见 --json；按『统计漂移修正』用扫描值覆盖")
+    print(f"六变量: {six} | {health}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 动机

六变量精校（`indexed_page_count` / `wiki_file_count` / `registered_domain_count` + `missing_count` / `broken_count` / `duplicate_count`）此前只有算法描述与 awk 快校，每次写命令都要临时新写 Python 脚本——存在口径漂移风险，且临时脚本散落在系统 Temp 无法维护。

## 改动

### 新增 `references/index_stat.py`（精校口径的唯一可执行实现）

- **六变量计算**完全对齐 SKILL.md §六变量计数口径：
  - `wiki_file_count`：`wiki/**/*.md`，排除 `index.md` / `log.md` / `*.canvas` / `templates/` / `assets/`
  - `registered_domain_count`：自动解析 schema『领域注册表』数据行数（CLAUDE.md 优先，AGENTS.md 行数对照，不一致时警告）
  - `indexed_page_count`：数据行 `[[title]]` 唯一解析 + 按 path 去重
  - `broken_count`：未命中 / 歧义（明细含歧义原因）；`missing_count` / `duplicate_count` 按口径
- **排除项**：`raw/...` 源链接、附件扩展名（.canvas/图片/PDF 等）、代码块与行内代码中的示例占位链接（如 `[[页面标题]]`）
- **页脚漂移对照**：自动读取 index.md 页脚旧六变量，输出 `footer_match` 与 drift 报告，直接服务『统计漂移修正』
- **双模式**：人类可读（默认，含 MISSING/BROKEN/DUP 明细）+ `--json` 机读；Windows GBK 控制台已做 UTF-8 处理；`pathlib.Path` + 显式参数，跨平台中文路径友好

### SKILL.md 三处引用

- §六变量计数口径 · 机检：**直接运行固定脚本，不要每次临时新写**；保留算法描述作为脚本不可用时的降级路径；bash 示例补充调用方式（`<skill_base>` / `<vault>` / `<python>` 占位符，不绑定本机路径）
- 写后自检第 8 步与 lint 校验规则第 7 条同步引用

### README.md

- lint 命令描述补充脚本提及

## 验证

在真实 vault（506 个 wiki 文件）实测：

```
wiki_file_count:         506
indexed_page_count:      504
registered_domain_count: 19
missing_count:           2
broken_count:            0
duplicate_count:         0
页脚对照: 一致（footer_match=true）
```

- `registered_domain_count` 从 schema 领域注册表自动解析正确
- `--json` 输出结构完整（含 footer / drift / 明细数组）

## 隐私

新增内容全部占位符化，无本机绝对路径、无密钥；`.claude/`、`.vscode/` 本地配置已由 .gitignore 排除。