### PR TITLE
feat: PDF 固定预处理与任务级临时目录清理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # 本地编辑器 / Agent 配置,含本地绝对路径与个人偏好,不属可分发内容
 .claude/
 .vscode/
+# Python 字节码缓存
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ claude mcp add -s user zai-mcp-server --env Z_AI_API_KEY=YOUR_API_KEY -- npx -y 
 - 双入口 schema 字节一致：结构变更同步两文件并验 SHA-256
 - 不虚构来源、数据、引用或验证结果
 - 中文路径与带空格路径用 `-LiteralPath` 或显式参数，不走 PowerShell 管道
+- 任务临时产物统一放 `<vault>/tmp/obsidian-llm-wiki/<task-id>/`，收尾按 `created_files.json` 逐文件清理（见 `references/temp-cleanup.md`）
 
 ## 文件结构
 
@@ -125,11 +126,14 @@ claude mcp add -s user zai-mcp-server --env Z_AI_API_KEY=YOUR_API_KEY -- npx -y 
 │   ├── tool-page.md      # 工具页面
 │   └── log-active.md     # 新活动日志模板（仅在一次成功分卷轮转后使用）
 ├── scripts/
-│   └── log-preflight.ps1 # 固定只读日志预检（2 MiB 阈值 + 跨年判定；Git Bash 经 powershell.exe 调用，中文文本走 -PendingAppendB64）
+│   ├── log-preflight.ps1 # 固定只读日志预检（2 MiB 阈值 + 跨年判定；Git Bash 经 powershell.exe 调用，中文文本走 -PendingAppendB64）
+│   └── preprocess_pdf.py # 固定 PDF 预处理（pypdf/PyMuPDF 双提取器 + 逐页乱码质量判定 + created_files.json 清理清单）
 └── references/
-    ├── schema.md         # AGENTS.md / CLAUDE.md 通用模板（供新项目初始化）
-    ├── index_stat.py     # index.md 六变量精校脚本
-    └── log-rotation.md   # 日志分卷/轮转参考（log status / query / rotate）
+    ├── schema.md              # AGENTS.md / CLAUDE.md 通用模板（供新项目初始化）
+    ├── index_stat.py          # index.md 六变量精校脚本
+    ├── log-rotation.md        # 日志分卷/轮转参考（log status / query / rotate）
+    ├── pdf-preprocessing.md   # PDF 预处理协议（固定入口、质量判定、视觉降级）
+    └── temp-cleanup.md        # 任务临时目录清理协议（created_files.json 驱动）
 ```
 
 ### Obsidian 仓库结构
@@ -207,6 +211,33 @@ logs/archive/log-YYYY-MM-DD-to-YYYY-MM-DD.md    # 历史分卷，永久只读
 
 轮转采用**整文件移动**（绝不"复制后清空"、剪切条目或改写历史），移动前后校验字节长度、条目数与 SHA-256 完全一致；新活动日志从 `assets/log-active.md` 模板创建，不复制旧条目。`logs/` 不计入 `index.md` 页面统计。**轮转是组织行为，不是备份**——历史分卷永不自动删除、压缩或合并。完整流程见 [references/log-rotation.md](references/log-rotation.md)。
 
+## PDF 固定预处理与任务临时目录清理
+
+`ingest` 处理 PDF 不再临时编写解析脚本，统一走 Skill 自带固定脚本 `scripts/preprocess_pdf.py`（依赖项目 `.venv` 的 `pypdf` 与 `PyMuPDF`）：
+
+```bash
+PYTHONUTF8=1 PYTHONIOENCODING=utf-8 \
+  "<vault>/.venv/Scripts/python.exe" \
+  "<skill>/scripts/preprocess_pdf.py" \
+  --input "<PDF 绝对路径>" --vault-root "<vault>" --task-id "<时间戳-安全任务标识>"
+```
+
+- **双提取器逐页质量判定**：pypdf 优先负责中文文本与 PDF 元数据，PyMuPDF 负责页数、嵌入图片对象与整页渲染；逐页比较替换字符、控制字符与连续乱码比例。pypdf 不合格且 PyMuPDF 更优时逐页降级；两者都不合格时自动渲染整页 PNG 并标记「需视觉读取」——绝不把乱码当正文写入 wiki。
+- **固定产物**：`metadata.json`、`pages.json`、`page_text.md`、`image_manifest.csv`、`unique_image_manifest.csv`、`images/`、`rendered_pages/`，全部落在任务目录 `<vault>/tmp/obsidian-llm-wiki/<task-id>/`。任务目录运行前必须不存在，脚本拒绝覆盖；`task-id` 仅允许字母、数字、点、下划线、连字符。
+- **只读边界**：脚本只读取输入 PDF，不写 `raw/`、`wiki/`、`index.md`、`log.md` 或 Schema。
+- 完整协议见 [references/pdf-preprocessing.md](references/pdf-preprocessing.md)。
+
+### created_files.json 驱动的收尾清理
+
+脚本在 `created_files.json` 中登记本次创建的每个文件、目录（最深优先排序）、工作容器 `tmp/obsidian-llm-wiki/`（条件删除）与受保护的 `<vault>/tmp/`（永不删除）。任务收尾（成功与可控失败都一样）按 [references/temp-cleanup.md](references/temp-cleanup.md) 执行：
+
+1. 逐个单文件删除登记产物——每条命令只碰一个明确路径，最后删除 `created_files.json` 自身；
+2. 任务根目录文件数归零后，按最深优先逐个删除已确认为空的子目录与任务目录（窄例外：单路径非递归 `Remove-Item -LiteralPath`）；
+3. 工作容器为空时才删除容器本身；`<vault>/tmp/` 始终保留，`tmp/pdfs/` 等其他工作流目录不碰；
+4. 最终汇报生成数 / 删除数 / 文件残留数 / 目录残留数 / 任务根状态 / 容器状态——残留不为 0 不得声称清理完成。
+
+配置了命令守卫的运行时（如 ZCode 的 PreToolUse hook），建议把「tmp/temp 类目录内的单文件 `rm` 与单路径非递归 `Remove-Item`」配置为免审批放行，递归与目录级删除命令保持直接拦截——本清理协议正是按这一形态设计，实测全流程零弹窗。
+
 ## SKILL.md 关键内容
 
 SKILL.md 是 Skill 的核心配置，定义了：
@@ -217,6 +248,7 @@ SKILL.md 是 Skill 的核心配置，定义了：
 4. **工作流守则** —— raw/ 只读、覆盖前确认、日志 append-only、从 CLAUDE.md 读取配置而非硬编码
 5. **index.md 同步契约** —— 顶部维护块、底部三变量统计行（`indexed_page_count` / `wiki_file_count` / `registered_domain_count`）与索引健康行（`missing_count` / `broken_count` / `duplicate_count`）的精确格式、六变量计数口径、强制维护遍历（Mandatory Maintenance Pass）与所有写命令的同步刷新策略（`## Index Metadata And Statistics`）
 6. **运行时与网关适配** —— 读图前的视觉通道顺序探测（`Read` 单图 → 视觉理解 MCP 单图；智谱 GLM 等网关下 `Read` 图片可能仅返回 CDN 回执而无视觉内容，此时 `zai-mcp-server` 视觉 MCP 作为兜底通道，配置见上文「视觉 MCP 配置」）、两条通道都不可用时的 6 步降级（manifest 照建、视觉字段标"视觉未识别"、基于已有文字提炼、不虚构）、以及大 `log.md` 的追加前固定预检（`scripts/log-preflight.ps1`，2 MiB 阈值与跨年判定）与 EOF 直追（bash heredoc / `Add-Content -LiteralPath`，不为追加而整读；轮转见 `references/log-rotation.md`）。详见 SKILL.md `## 运行时与网关适配`
+7. **PDF 固定预处理与任务临时目录清理** —— PDF 必须走 Skill 自带 `scripts/preprocess_pdf.py`（先读 `references/pdf-preprocessing.md`，禁止临时另写脚本），产物只进 `<vault>/tmp/obsidian-llm-wiki/<task-id>/`；任务收尾按 `references/temp-cleanup.md` 的 `created_files.json` 清单逐文件删除、最深优先删除空任务目录、容器空则条件删除，并汇报六项指标。详见 SKILL.md「文档预处理运行时」与上文「PDF 固定预处理与任务临时目录清理」
 
 ## 快速开始
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-llm-wiki
-description: "LLM Wiki 模式：用 LLM 持续维护 Obsidian 知识库（raw/wiki 双层 + AGENTS.md/CLAUDE.md schema + index.md + log.md）。支持 ingest、query、optimize、extract-thinking-frameworks、lint、index、migrate、delete；强制维护遍历（Mandatory Maintenance Pass）自动检查并修复 frontmatter/index/schema 结构缺口；index.md 统一三权威变量（indexed_page_count/wiki_file_count/registered_domain_count）+ 三健康变量（missing_count/broken_count/duplicate_count）+ 索引健康行；双入口 schema 字节一致并验 SHA-256。支持用 Claude Code Agent 工具派发只读 subagent 以波次并行分析图片密集资料（截图课程、PPT、扫描件，支持 100–300 张多 Agents 并行读图），用项目 .venv 做 PDF/DOCX/PPTX/XLSX 预处理与 image manifest。触发词：wiki、知识库维护、ingest、preprocess、batch-analyze images、subagent、波次并行、manifest、venv、optimize、lint、index、索引健康、六变量统计、双入口 schema、补录、漂移修正、知识管理、Obsidian 笔记整理、读图降级、视觉通道探测、视觉 MCP、zai-mcp-server、GLM-4.6V、GLM/MiniMax 网关、log.md 大文件追加、固定只读日志预检（log-preflight.ps1，2 MiB 阈值与跨年判定）、日志分卷轮转、log status、log query、log rotate。"
+description: "LLM Wiki 模式：用 LLM 持续维护 Obsidian 知识库（raw/wiki 双层 + AGENTS.md/CLAUDE.md schema + index.md + log.md）。支持 ingest、query、optimize、extract-thinking-frameworks、lint、index、migrate、delete；强制维护遍历（Mandatory Maintenance Pass）自动检查并修复 frontmatter/index/schema 结构缺口；index.md 统一三权威变量（indexed_page_count/wiki_file_count/registered_domain_count）+ 三健康变量（missing_count/broken_count/duplicate_count）+ 索引健康行；双入口 schema 字节一致并验 SHA-256。支持用 Claude Code Agent 工具派发只读 subagent 以波次并行分析图片密集资料（截图课程、PPT、扫描件，支持 100–300 张多 Agents 并行读图），用项目 .venv 做 PDF/DOCX/PPTX/XLSX 预处理与 image manifest。触发词：wiki、知识库维护、ingest、preprocess、batch-analyze images、subagent、波次并行、manifest、venv、optimize、lint、index、索引健康、六变量统计、双入口 schema、补录、漂移修正、知识管理、Obsidian 笔记整理、读图降级、视觉通道探测、视觉 MCP、zai-mcp-server、GLM-4.6V、GLM/MiniMax 网关、log.md 大文件追加、固定只读日志预检（log-preflight.ps1，2 MiB 阈值与跨年判定）、日志分卷轮转、log status、log query、log rotate、固定 PDF 预处理（preprocess_pdf.py）、任务临时目录清理（tmp/obsidian-llm-wiki、created_files.json、temp-cleanup）。"
 ---
 
 # Obsidian LLM Wiki Skill
@@ -54,7 +54,7 @@ description: "LLM Wiki 模式：用 LLM 持续维护 Obsidian 知识库（raw/wi
   Remove-Item -LiteralPath "<绝对路径>"
   ```
 
-  单文件单命令；中文路径与带空格路径必须用 `-LiteralPath` 或被正确引用的显式参数。
+  单文件单命令；中文路径与带空格路径必须用 `-LiteralPath` 或被正确引用的显式参数。唯一目录删除例外：Skill 任务目录（`<vault-root>/tmp/obsidian-llm-wiki/<task-id>/`）内已清空、已确认为空的目录，按 [references/temp-cleanup.md](references/temp-cleanup.md) 逐个用非递归 `Remove-Item -LiteralPath` 删除。
 - **双入口 schema 字节一致性**：声明双入口契约时，`AGENTS.md` 与 `CLAUDE.md` 必须字节相同；结构变更**同步编辑两文件并验证 SHA-256**；不得泄露密钥或本地敏感配置。
 - **subagent 只读红线**：派出的 subagent 绝不修改 `raw/`、`wiki/`、`index.md`、`log.md`、schema 文件或 `.claude/` 下任何文件。
 - 不确定时**提问，不猜测**；图片重名/缺失/无法唯一定位一律先报告。
@@ -63,6 +63,7 @@ description: "LLM Wiki 模式：用 LLM 持续维护 Obsidian 知识库（raw/wi
 - 图片嵌入用短文件名 `![[文件名.png]]`，不写完整路径（Obsidian 全库自动解析）。
 - **图片视觉未识别时必须如实标注**（视觉未识别 / 基于正文非图像识别），绝不依文件名或上下文虚构图中文字、人物、数字、颜色。
 - **`log.md` 大文件（超 `Read` 上限）追加用 EOF 直追**（bash heredoc / `Add-Content -LiteralPath`），不为追加而整读。
+- **任务临时文件自动清理**：杂项中转/对账临时文件只放系统临时目录（Git Bash `/tmp`，即 Windows `%TEMP%`，如 `C:/Users/<用户名>/AppData/Local/Temp/`）；Skill 管理的任务产物（如 PDF 预处理中间产物）统一放任务目录 `<vault-root>/tmp/obsidian-llm-wiki/<task-id>/`；两者均禁止写入 `raw/`、`wiki/` 或 vault 其他位置。优先用命令内变量、命令替换与进程替换（如 `diff <(...) <(...)`）内联完成，不落盘；确需落盘时，任务收尾按 [references/temp-cleanup.md](references/temp-cleanup.md) 自动清理，无需用户确认（若运行时配置了命令守卫，tmp/temp 类目录下的单文件 `rm` 与单路径非递归删除可配置为免审批放行——后者是空任务目录窄例外的唯一删除方式；目录级与递归删除仍应直接拦截）；系统临时目录与任务目录均不得残留任务临时文件。
 
 ## 前置条件（初始化）
 
@@ -127,6 +128,18 @@ PDF/DOCX/PPTX/XLSX 等文档的确定性预处理，与只读 subagent 视觉分
 & ".\.venv\Scripts\python.exe" ".\scripts\<script>.py" "<input-path>" "<output-path>"
 ```
 
+**PDF 固定脚本（强制，禁止临时另写）**：处理 PDF 前必须先读 [references/pdf-preprocessing.md](references/pdf-preprocessing.md)，再运行 Skill 自带 `scripts/preprocess_pdf.py`（pypdf 优先中文文本、PyMuPDF 负责页数/图片/整页渲染，逐页乱码质量判定，固定产出 pages/manifest/`created_files.json`）。Git Bash 调用：
+
+```bash
+PYTHONUTF8=1 PYTHONIOENCODING=utf-8 \
+  "<vault-root>/.venv/Scripts/python.exe" \
+  "<skill_base>/scripts/preprocess_pdf.py" \
+  --input "<PDF 绝对路径>" --vault-root "<知识库绝对路径>" --task-id "<时间戳-安全任务标识>"
+```
+
+- 产物只进任务目录 `<vault-root>/tmp/obsidian-llm-wiki/<task-id>/`；`task-id` 运行前必须不存在（脚本拒绝覆盖）；`requires_visual` 页按「运行时与网关适配」三级视觉通道读图。
+- **清理触发**：成功与可控失败的任务，都要在构建最终日志与最终回复前按 [references/temp-cleanup.md](references/temp-cleanup.md) 清理：先逐个单文件删除登记产物，再按 `created_directories` 最深优先删除空任务目录（窄例外单路径非递归 `Remove-Item -LiteralPath`），工作容器空则条件删除；最终汇报生成数/删除数/文件残留数/目录残留数/任务根状态/容器状态。
+
 **`.venv` 职责**（确定性、可重复）：
 - 从 DOCX / PDF / PPTX / XLSX 提取文本与元数据
 - 提取或枚举内嵌图片、slide/page 顺序、文件名、尺寸、源文档引用
@@ -139,7 +152,7 @@ PDF/DOCX/PPTX/XLSX 等文档的确定性预处理，与只读 subagent 视觉分
 - 只读 subagent 负责 OCR-like 图片阅读、截图理解、图表/UI 细节、概念洞见合成
 - **不默认假设** Tesseract、OpenCV、PaddleOCR、RapidOCR 等传统 OCR 引擎可用，除非用户明确安装或要求
 
-> 项目 `scripts/` 是否就位、依赖是否安装，以项目 schema（CLAUDE.md 的「运行环境」章节）为准；未就位时 PDF 用 Read 的 `pages` 参数直读降级。
+> PDF 依赖（`pypdf`、`PyMuPDF`）以项目 `.venv` 为准；缺依赖且用户未授权安装时，PDF 用 Read 的 `pages` 参数直读降级。DOCX/PPTX/XLSX 项目脚本是否就位、依赖是否安装，仍以项目 schema（CLAUDE.md 的「运行环境」章节）为准。
 
 ## 图片密集资料分析（Image-Heavy Source Analysis）
 
@@ -266,6 +279,8 @@ PDF/DOCX/PPTX/XLSX 等文档的确定性预处理，与只读 subagent 视觉分
   powershell.exe -NoProfile -ExecutionPolicy Bypass -File "<skill_base>/scripts/log-preflight.ps1" \
     -VaultRoot "<vault_root>" -PendingAppendB64 "$PENDING_B64" -ThresholdMiB 2 -Json
   ```
+
+  `PENDING` 与 `PENDING_B64` 全程用命令内变量构造（heredoc / 命令替换），**禁止为预检或追加在 vault 或项目目录落盘中转文件**；对账类中间产物（嵌入清单、文件清单对比等）优先用进程替换内联（如 `diff <(cmd1) <(cmd2)`）；确需临时文件时放系统临时目录并在任务收尾自动删除（见「安全规则」的任务临时文件自动清理条目）。
 
 - 原生 PowerShell（Codex 或 pwsh 会话）——可直接传明文参数：
 
@@ -521,7 +536,7 @@ missing_count / broken_count / duplicate_count ==  当次扫描结果
 处理 `raw/` 中的新来源，集成到 wiki。
 
 1. 确认来源文件在 `raw/` 对应目录中
-2. **文档预处理**（条件性）：PDF/DOCX/PPTX/XLSX 或大量图片，`scripts/` 就位时用 `.venv` 预处理并建立 manifest；未就位时 PDF 用 Read 的 `pages` 参数直读
+2. **文档预处理**（条件性）：PDF 必须走 Skill 固定脚本 `scripts/preprocess_pdf.py`（先读 references/pdf-preprocessing.md，见「文档预处理运行时」），收尾按 temp-cleanup.md 清理任务目录；DOCX/PPTX/XLSX 或大量图片在 `scripts/` 就位时用 `.venv` 预处理并建立 manifest；PDF 依赖未就位时用 Read 的 `pages` 参数直读
 3. **图片密集分析**：图片密集资料按 image manifest 分析；先做视觉通道顺序探测（`Read` → 视觉 MCP，见「运行时与网关适配」），超过 10 张派只读 subagent 并行分析，100–300 张以波次推进（见「Subagent 批量分析」）
 4. **核对 manifest**：阅读/分析时核对覆盖率、顺序、缺失、重名，异常先报告
 5. 与用户讨论关键要点
@@ -608,7 +623,7 @@ missing_count / broken_count / duplicate_count ==  当次扫描结果
 
 ### /obsidian-llm-wiki delete \<page\>
 
-删除 wiki 页面（**不动 raw/**）。删除前：确认无其他页面的入链，或有则提示用户处理断链。删除动作：用 `Remove-Item -LiteralPath "<绝对路径>"`，禁通配符/`-Recurse`/批量/目录删除。删除后**运行强制维护遍历**：在对应 `## <领域>` 章节删除该行；检查相关链接/反向链接/index 是否需要更新；`indexed_page_count` 变化则重算六变量；顶部维护块摘要 = `同步索引：移除 1 个页面（<页面名>）`；追加 `log.md` 条目 `## [YYYY-MM-DD] delete | <标题>`，日期与 index 顶部/底部字面一致。
+删除 wiki 页面（**不动 raw/**）。删除前：确认无其他页面的入链，或有则提示用户处理断链。删除动作：用 `Remove-Item -LiteralPath "<绝对路径>"`，禁通配符/`-Recurse`/批量/目录删除（唯一例外：Skill 任务临时目录的空目录窄例外，见 [references/temp-cleanup.md](references/temp-cleanup.md)）。删除后**运行强制维护遍历**：在对应 `## <领域>` 章节删除该行；检查相关链接/反向链接/index 是否需要更新；`indexed_page_count` 变化则重算六变量；顶部维护块摘要 = `同步索引：移除 1 个页面（<页面名>）`；追加 `log.md` 条目 `## [YYYY-MM-DD] delete | <标题>`，日期与 index 顶部/底部字面一致。
 
 ### /obsidian-llm-wiki log \<mode\>
 

--- a/references/pdf-preprocessing.md
+++ b/references/pdf-preprocessing.md
@@ -1,0 +1,81 @@
+# PDF 预处理协议（pdf-preprocessing.md）
+
+本 reference 只规定 PDF 的文本、页码、元数据、图片对象与视觉降级流程。
+临时文件清理由独立的 [temp-cleanup.md](temp-cleanup.md) 负责；不要把两个工作流合并。
+
+## 固定入口
+
+PDF 预处理使用 Skill 自带固定脚本，不为普通 PDF 任务临时生成另一份预处理脚本。
+解释器用知识库项目虚拟环境（`.venv/Scripts/python.exe`），Git Bash 调用格式：
+
+```bash
+PYTHONUTF8=1 PYTHONIOENCODING=utf-8 \
+  "<vault-root>/.venv/Scripts/python.exe" \
+  "<skill_base>/scripts/preprocess_pdf.py" \
+  --input "<PDF 绝对路径>" \
+  --vault-root "<知识库绝对路径>" \
+  --task-id "<时间戳-安全任务标识>"
+```
+
+其中 `<skill_base>` 即本 Skill 的安装根目录（随运行时不同，如 ZCode 为 `~/.zcode/skills/obsidian-llm-wiki`、Claude Code 为 `~/.claude/skills/obsidian-llm-wiki`）。约束：
+
+- `task-id` 只能包含字母、数字、点、下划线和连字符，且不能是 `.` 或 `..`。
+- 输出目录固定为 `<vault-root>/tmp/obsidian-llm-wiki/<task-id>/`。
+- 任务目录必须在运行前不存在；脚本拒绝覆盖或复用既有目录。
+- 脚本只读取输入 PDF，不修改 `raw/`，也不写入 `wiki/`、`index.md`、`log.md` 或 Schema。
+- 中间产物只进入任务目录，不落在 `raw/` 或 vault 其他位置。
+
+## 提取器分工
+
+- `pypdf` 优先负责中文文本与 PDF 元数据。
+- PyMuPDF 负责页数、页面尺寸、嵌入图片对象、xref、图片尺寸与必要的整页渲染。
+- 不要把 PyMuPDF 的文本结果默认当作中文正文。它只在 pypdf 质量不合格且自身质量更高时作为逐页降级结果。
+- 不要因为终端显示乱码就判断文件损坏；先确保 UTF-8 环境（`PYTHONUTF8=1`），再检查脚本输出的逐页质量指标。
+
+## 乱码与质量判定
+
+脚本对每页分别计算替换字符比例、控制字符比例与连续替换字符，并按以下顺序决策：
+
+1. `pypdf` 有文本且未超过异常阈值时，选用 `pypdf`（状态 `ok`）。
+2. `pypdf` 不合格时比较 PyMuPDF；只有 PyMuPDF 通过阈值且质量更高时才选用它（状态 `fallback`）。
+3. 两者文本都为空时，状态为 `empty_text`。
+4. 两者都疑似乱码时，状态为 `corrupt_text`。
+5. `empty_text` 和 `corrupt_text` 页面自动渲染为 PNG（`rendered_pages/page-NNN.png`），页面正文位置只写「需视觉读取」，不得把乱码写入 Wiki。
+
+质量检测是风险筛选，不替代内容核对。
+
+## 视觉读取衔接
+
+`requires_visual` 页面与提取图片的视觉理解，按 SKILL.md「运行时与网关适配」的三级通道执行：
+先试 `Read` 直读；不可用时用视觉理解 MCP（如智谱 `zai-mcp-server`，`analyze_image` / `extract_text_from_screenshot` 等，`image_source` 传本地绝对路径）；仍不可用才标记「视觉未识别」降级。
+不假设 Tesseract、OpenCV、PaddleOCR、RapidOCR 等传统 OCR 引擎可用。
+
+## 固定产物
+
+全部位于 `<vault-root>/tmp/obsidian-llm-wiki/<task-id>/`：
+
+| 文件/目录 | 内容 |
+|---|---|
+| `metadata.json` | 来源路径、SHA-256、页数、双提取器元数据、`text_priority`、`visual_pages` |
+| `pages.json` | 逐页状态、选中提取器、质量指标、文本、图片出现数 |
+| `page_text.md` | 按页分节正文；异常页只有「需视觉读取」占位 |
+| `image_manifest.csv` | 图片出现级清单（页码、occurrence、xref、尺寸） |
+| `unique_image_manifest.csv` | xref 去重图片清单（含 pages、occurrence_count、sha256） |
+| `images/` | 唯一嵌入图片（`xref-<xref>.<ext>`） |
+| `rendered_pages/` | 仅异常页整页渲染 PNG |
+| `created_files.json` | 本次创建的普通文件清单、建议清理顺序、`created_directories`、容器与保护路径标注 |
+
+`created_files.json` 关键字段：
+
+- `cleanup_order`（与 `created_files` 相同）：建议清理顺序，清单自身排在最后一位；
+- `created_directories`：本次创建的目录，按最深优先排序；
+- `conditional_cleanup_directory`：即 `<vault-root>/tmp/obsidian-llm-wiki/`，单独标注、条件删除；
+- `protected_tmp_root`：即 `<vault-root>/tmp/`，永不删除；
+- `workflow_root_created_by_task`：本次运行是否新建了工作容器。
+
+脚本标准输出返回一行 JSON 摘要（`task_root`、`pages`、`text_chars`、`visual_pages`、`image_occurrences`、`unique_images`、`created_files`）。后续图片分析必须按 manifest 索引对账；不得依赖文件系统返回顺序。
+
+## 使用边界
+
+- 完成页面、索引和必要验证后，再进入独立的临时文件清理流程（[temp-cleanup.md](temp-cleanup.md)）。
+- 中断恢复时只能继续处理已知 task-id 和它的登记清单，不能遍历同级历史目录。

--- a/references/temp-cleanup.md
+++ b/references/temp-cleanup.md
@@ -1,0 +1,86 @@
+# 临时文件与目录清理协议（temp-cleanup.md）
+
+本 reference 规定 `tmp/obsidian-llm-wiki/` 任务产物的收尾清理。与 [pdf-preprocessing.md](pdf-preprocessing.md) 是两个独立工作流，不要合并执行。
+
+## 权限边界
+
+- 每次任务使用独立且运行前不存在的任务根目录：`<vault-root>/tmp/obsidian-llm-wiki/<task-id>/`。
+- 清理权限只来自该次运行生成的 `created_files.json`，不能从「文件位于 tmp 下」推断可删除。
+- 不扫描或清理同级其他任务目录，不清理历史遗留目录，不处理未登记文件。
+- 永远不删除 `raw/`、`wiki/`、`index.md`、`log.md`、Schema、Skill 文件或任务根目录之外的任何文件。
+- 普通目录仍禁止删除。唯一例外是本 reference 规定的本次任务空目录与空的 `tmp/obsidian-llm-wiki/` 工作容器。
+- 始终保留 `<vault-root>/tmp/` 本身，不处理 `tmp/pdfs/` 等其他工作流或历史目录。
+
+## 清理时机
+
+- 页面、索引和必要验证完成后，在构建最终日志文字及最终回复前执行清理。
+- 成功和可控失败都要进入清理阶段。
+- 只有用户明确要求保留调试材料时才能跳过，并须列出保留路径。
+- 中断后恢复时，只能继续处理已知 `task-id` 和对应登记清单，不能遍历同级目录寻找「可能属于本任务」的文件。
+
+## 冻结清单
+
+1. 读取 `created_files.json`，在删除前把完整清理顺序冻结在当前工作上下文。
+2. `created_files.json` 自身必须是清理顺序中的最后一项。
+3. 同时冻结 `created_directories`、`conditional_cleanup_directory` 和 `protected_tmp_root`；不得在清理过程中通过扫描发现新删除目标。
+4. 对每个文件目标分别确认：
+   - 登记在本次清单中；
+   - 是普通文件，不是目录；
+   - 解析后仍严格位于本次任务根目录；
+   - 路径不含 `*` 或 `?`；
+   - 不属于任何受保护路径。
+5. 任一文件目标验证失败时，不删除该目标；继续处理其他已登记文件，但不得开始目录清理，并在最终结果中报告。
+
+## 逐文件删除
+
+每个文件必须使用一次独立命令。不得把多个路径放进一个命令，不得用循环、管道、通配符、`-Recurse`、`rm -rf` 或删除 Python。
+Git Bash 单文件 `rm` 与 PowerShell 单路径非递归 `Remove-Item` 是等价首选（每个命令只碰一个明确路径）；若运行时配置了命令守卫，两种形态都应配置为对 tmp/temp 类目录内的单一路径免审批放行：
+
+```bash
+rm "<vault-root>/tmp/obsidian-llm-wiki/<task-id>/metadata.json"
+```
+
+等价备选（同一文件只删一次）：
+
+```bash
+powershell.exe -NoProfile -Command "Remove-Item -LiteralPath '<vault-root>/tmp/obsidian-llm-wiki/<task-id>/metadata.json'"
+```
+
+按清单顺序删除普通产物，最后单独删除 `created_files.json`。每条命令只对应一个明确文件；路径用正斜杠，含空格路径加引号。
+
+## 逐目录删除窄例外
+
+只有全部登记文件均已删除且任务根目录内普通文件数为 0，才能开始目录清理。
+
+1. 按 `created_directories` 的既定顺序处理：最深层子目录在前，任务根目录最后。
+2. 每个目录必须分别确认：
+   - 路径来自 `created_directories`，或恰好等于 `conditional_cleanup_directory`；
+   - 是目录且为空（`ls -A "<目录>"` 无任何输出）；
+   - 路径不含 `*` 或 `?`；
+   - 解析后位于本次任务根目录内，或恰好是 `<vault-root>/tmp/obsidian-llm-wiki/`；
+   - 不等于 `protected_tmp_root`，也不位于 `tmp/pdfs/` 等其他工作流路径。
+3. 每个空目录使用一次独立命令：
+
+```bash
+powershell.exe -NoProfile -Command "Remove-Item -LiteralPath '<vault-root>/tmp/obsidian-llm-wiki/<task-id>/images'"
+```
+
+4. 任务目录删除后，只读检查 `conditional_cleanup_directory`。仅当其中没有任何文件或目录时，才用另一条独立命令删除该工作容器。
+5. 任一目录非空、校验失败或删除失败时，停止向上删除；不得改用 `-Recurse`、循环、管道或其他批量方式补救。
+6. 递归与目录级删除命令（`rmdir`、`rm -r`/`rm -rf`、`Remove-Item -Recurse`）一律禁止使用；配置了命令守卫的运行时应保持对其直接拦截。若沙箱或审批策略拒绝目录删除，视为受控残留：不要换用其他等价方式绕过，保留空目录并报告具体阻断。
+7. 严格保持单调用形态：powershell 单次调用、仅 `-LiteralPath`/`-Path` + 单一路径、无其他参数；任何附加参数都会回落审批或被拦截。
+
+## 清理验证与结果报告
+
+删除任务目录前，只读检查本次任务根目录：
+
+```bash
+find "<本次任务根目录>" -type f
+```
+
+- 返回普通文件数必须为 0。
+- 不得因为验证发现其他任务目录仍有文件而扩大清理范围。
+- 最终汇报六项：生成文件数、成功删除文件数、文件残留数、目录残留数、任务目录状态和工作容器状态。
+- 最佳结果是 `<vault-root>/tmp/` 保留，而 `tmp/obsidian-llm-wiki/` 因为空而被删除。
+- 文件或任务目录残留不为 0 时列出残留项，不得声称完整清理完成。
+- 因策略阻断而仅剩空目录时，必须明确区分「文件已清空」和「目录删除未获执行许可」。

--- a/scripts/preprocess_pdf.py
+++ b/scripts/preprocess_pdf.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import fitz
+from pypdf import PdfReader
+
+
+SAFE_TASK_ID = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Preprocess a PDF for obsidian-llm-wiki without modifying raw sources."
+    )
+    parser.add_argument("--input", required=True, type=Path, help="Absolute PDF path")
+    parser.add_argument(
+        "--vault-root", required=True, type=Path, help="Absolute Obsidian vault root"
+    )
+    parser.add_argument(
+        "--task-id",
+        required=True,
+        help="Unique task id using only letters, digits, dot, underscore, and hyphen",
+    )
+    return parser.parse_args()
+
+
+def validate_task_id(task_id: str) -> None:
+    if task_id in {".", ".."} or not SAFE_TASK_ID.fullmatch(task_id):
+        raise ValueError(
+            "task-id must use only letters, digits, dot, underscore, and hyphen"
+        )
+
+
+def quality_metrics(text: str) -> dict[str, Any]:
+    length = len(text)
+    replacement_count = text.count("\ufffd")
+    control_count = sum(
+        1 for char in text if ord(char) < 32 and char not in "\n\r\t"
+    )
+    replacement_ratio = replacement_count / max(length, 1)
+    control_ratio = control_count / max(length, 1)
+    repeated_replacement = bool(re.search(r"\ufffd{2,}|���", text))
+    acceptable = bool(text.strip()) and replacement_ratio <= 0.01 and control_ratio <= 0.005 and not repeated_replacement
+    penalty = replacement_count * 100 + control_count * 50 + (1000 if repeated_replacement else 0)
+    return {
+        "chars": length,
+        "replacement_count": replacement_count,
+        "replacement_ratio": round(replacement_ratio, 6),
+        "control_count": control_count,
+        "control_ratio": round(control_ratio, 6),
+        "repeated_replacement": repeated_replacement,
+        "acceptable": acceptable,
+        "penalty": penalty,
+    }
+
+
+def choose_text(pypdf_text: str, pymupdf_text: str) -> tuple[str, str, str, dict[str, Any], dict[str, Any]]:
+    pypdf_metrics = quality_metrics(pypdf_text)
+    pymupdf_metrics = quality_metrics(pymupdf_text)
+    if pypdf_metrics["acceptable"]:
+        return pypdf_text, "pypdf", "ok", pypdf_metrics, pymupdf_metrics
+    if pymupdf_metrics["acceptable"] and pymupdf_metrics["penalty"] < pypdf_metrics["penalty"]:
+        return pymupdf_text, "pymupdf", "fallback", pypdf_metrics, pymupdf_metrics
+    if not pypdf_text.strip() and not pymupdf_text.strip():
+        return "", "none", "empty_text", pypdf_metrics, pymupdf_metrics
+    return "", "none", "corrupt_text", pypdf_metrics, pymupdf_metrics
+
+
+def jsonable_metadata(metadata: Any) -> dict[str, Any]:
+    if metadata is None:
+        return {}
+    try:
+        return {str(key): value for key, value in dict(metadata).items()}
+    except Exception:
+        return {"value": str(metadata)}
+
+
+def main() -> int:
+    args = parse_args()
+    validate_task_id(args.task_id)
+
+    input_pdf = args.input.resolve(strict=True)
+    vault_root = args.vault_root.resolve(strict=True)
+    if not input_pdf.is_file() or input_pdf.suffix.lower() != ".pdf":
+        raise ValueError("input must be an existing PDF file")
+    if not vault_root.is_dir():
+        raise ValueError("vault-root must be an existing directory")
+
+    protected_tmp_root = (vault_root / "tmp").resolve()
+    task_root = (protected_tmp_root / "obsidian-llm-wiki" / args.task_id).resolve()
+    allowed_parent = (protected_tmp_root / "obsidian-llm-wiki").resolve()
+    if task_root.parent != allowed_parent:
+        raise ValueError("task root escaped tmp/obsidian-llm-wiki")
+    if task_root.exists():
+        raise FileExistsError(f"task root already exists: {task_root}")
+
+    workflow_root_created_by_task = not allowed_parent.exists()
+    task_root.mkdir(parents=True, exist_ok=False)
+    created_files: list[Path] = []
+    created_directories: list[Path] = [task_root.resolve()]
+    image_dir = task_root / "images"
+    rendered_dir = task_root / "rendered_pages"
+    manifest_path = task_root / "created_files.json"
+
+    def ensure_directory(path: Path) -> None:
+        if not path.exists():
+            path.mkdir(parents=False, exist_ok=False)
+            created_directories.append(path.resolve())
+
+    def write_text(path: Path, content: str) -> None:
+        ensure_directory(path.parent)
+        with path.open("w", encoding="utf-8") as handle:
+            created_files.append(path.resolve())
+            handle.write(content)
+
+    def write_bytes(path: Path, content: bytes) -> None:
+        ensure_directory(path.parent)
+        with path.open("wb") as handle:
+            created_files.append(path.resolve())
+            handle.write(content)
+
+    try:
+        source_bytes = input_pdf.read_bytes()
+        source_hash = hashlib.sha256(source_bytes).hexdigest()
+        pypdf_reader = PdfReader(input_pdf)
+        pymupdf_document = fitz.open(input_pdf)
+        if len(pypdf_reader.pages) != pymupdf_document.page_count:
+            raise ValueError("page count differs between pypdf and PyMuPDF")
+
+        pages: list[dict[str, Any]] = []
+        page_text_parts: list[str] = []
+        image_rows: list[dict[str, Any]] = []
+        unique_images: dict[int, dict[str, Any]] = {}
+        visual_pages: list[int] = []
+
+        for page_number in range(1, pymupdf_document.page_count + 1):
+            fitz_page = pymupdf_document[page_number - 1]
+            try:
+                pypdf_text = (pypdf_reader.pages[page_number - 1].extract_text() or "").strip()
+            except Exception as exc:
+                pypdf_text = ""
+                pypdf_error = f"{type(exc).__name__}: {exc}"
+            else:
+                pypdf_error = None
+            try:
+                pymupdf_text = fitz_page.get_text("text", sort=True).strip()
+            except Exception as exc:
+                pymupdf_text = ""
+                pymupdf_error = f"{type(exc).__name__}: {exc}"
+            else:
+                pymupdf_error = None
+
+            selected_text, extractor, status, pypdf_quality, pymupdf_quality = choose_text(
+                pypdf_text, pymupdf_text
+            )
+            requires_visual = status in {"empty_text", "corrupt_text"}
+            rendered_path: Path | None = None
+            if requires_visual:
+                visual_pages.append(page_number)
+                pixmap = fitz_page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+                rendered_path = rendered_dir / f"page-{page_number:03d}.png"
+                write_bytes(rendered_path, pixmap.tobytes("png"))
+
+            images = fitz_page.get_images(full=True)
+            for occurrence, image_info in enumerate(images, start=1):
+                xref = int(image_info[0])
+                if xref not in unique_images:
+                    image = pymupdf_document.extract_image(xref)
+                    extension = str(image.get("ext", "bin"))
+                    image_path = image_dir / f"xref-{xref}.{extension}"
+                    write_bytes(image_path, image["image"])
+                    unique_images[xref] = {
+                        "xref": xref,
+                        "filename": image_path.name,
+                        "absolute_path": str(image_path.resolve()),
+                        "width": int(image_info[2]),
+                        "height": int(image_info[3]),
+                        "sha256": hashlib.sha256(image["image"]).hexdigest(),
+                        "pages": [],
+                    }
+                unique_images[xref]["pages"].append(page_number)
+                image_rows.append(
+                    {
+                        "manifest_index": len(image_rows) + 1,
+                        "page": page_number,
+                        "occurrence": occurrence,
+                        "xref": xref,
+                        "filename": unique_images[xref]["filename"],
+                        "absolute_path": unique_images[xref]["absolute_path"],
+                        "width": int(image_info[2]),
+                        "height": int(image_info[3]),
+                        "status": "extracted",
+                    }
+                )
+
+            page_record = {
+                "page": page_number,
+                "status": status,
+                "selected_extractor": extractor,
+                "requires_visual": requires_visual,
+                "rendered_page": str(rendered_path.resolve()) if rendered_path else None,
+                "text_chars": len(selected_text),
+                "text": selected_text,
+                "image_occurrences": len(images),
+                "pypdf_quality": pypdf_quality,
+                "pymupdf_quality": pymupdf_quality,
+                "pypdf_error": pypdf_error,
+                "pymupdf_error": pymupdf_error,
+            }
+            pages.append(page_record)
+            page_body = selected_text if selected_text else f"[第 {page_number} 页需视觉读取：{status}]"
+            page_text_parts.append(f"## 第 {page_number} 页\n\n{page_body}\n")
+
+        metadata = {
+            "source": str(input_pdf),
+            "sha256": source_hash,
+            "file_size": len(source_bytes),
+            "page_count": pymupdf_document.page_count,
+            "pypdf_metadata": jsonable_metadata(pypdf_reader.metadata),
+            "pymupdf_metadata": pymupdf_document.metadata,
+            "text_priority": ["pypdf", "pymupdf", "visual"],
+            "visual_pages": visual_pages,
+        }
+        write_text(
+            task_root / "metadata.json",
+            json.dumps(metadata, ensure_ascii=False, indent=2),
+        )
+        write_text(
+            task_root / "pages.json",
+            json.dumps(pages, ensure_ascii=False, indent=2),
+        )
+        write_text(task_root / "page_text.md", "\n".join(page_text_parts))
+
+        image_fields = [
+            "manifest_index",
+            "page",
+            "occurrence",
+            "xref",
+            "filename",
+            "absolute_path",
+            "width",
+            "height",
+            "status",
+        ]
+        image_manifest_path = task_root / "image_manifest.csv"
+        with image_manifest_path.open("w", encoding="utf-8-sig", newline="") as handle:
+            created_files.append(image_manifest_path.resolve())
+            writer = csv.DictWriter(handle, fieldnames=image_fields)
+            writer.writeheader()
+            writer.writerows(image_rows)
+
+        unique_fields = [
+            "unique_index",
+            "xref",
+            "filename",
+            "absolute_path",
+            "pages",
+            "occurrence_count",
+            "width",
+            "height",
+            "sha256",
+            "status",
+        ]
+        unique_rows: list[dict[str, Any]] = []
+        for unique_index, item in enumerate(unique_images.values(), start=1):
+            pages_for_image = list(item["pages"])
+            unique_rows.append(
+                {
+                    "unique_index": unique_index,
+                    "xref": item["xref"],
+                    "filename": item["filename"],
+                    "absolute_path": item["absolute_path"],
+                    "pages": ",".join(str(page) for page in pages_for_image),
+                    "occurrence_count": len(pages_for_image),
+                    "width": item["width"],
+                    "height": item["height"],
+                    "sha256": item["sha256"],
+                    "status": "extracted",
+                }
+            )
+        unique_manifest_path = task_root / "unique_image_manifest.csv"
+        with unique_manifest_path.open("w", encoding="utf-8-sig", newline="") as handle:
+            created_files.append(unique_manifest_path.resolve())
+            writer = csv.DictWriter(handle, fieldnames=unique_fields)
+            writer.writeheader()
+            writer.writerows(unique_rows)
+
+        summary = {
+            "task_root": str(task_root),
+            "source_sha256": source_hash,
+            "pages": pymupdf_document.page_count,
+            "text_chars": sum(page["text_chars"] for page in pages),
+            "visual_pages": visual_pages,
+            "image_occurrences": len(image_rows),
+            "unique_images": len(unique_rows),
+        }
+    except Exception:
+        summary = {
+            "task_root": str(task_root),
+            "status": "failed",
+            "error": f"{type(sys.exc_info()[1]).__name__}: {sys.exc_info()[1]}",
+        }
+        raise
+    finally:
+        cleanup_order = [str(path) for path in created_files] + [str(manifest_path.resolve())]
+        unique_created_directories = list(dict.fromkeys(created_directories))
+        directory_cleanup_order = [
+            str(path)
+            for path in sorted(
+                unique_created_directories,
+                key=lambda item: len(item.parts),
+                reverse=True,
+            )
+        ]
+        manifest = {
+            "task_root": str(task_root),
+            "created_files": cleanup_order,
+            "cleanup_order": cleanup_order,
+            "created_directories": directory_cleanup_order,
+            "conditional_cleanup_directory": str(allowed_parent),
+            "workflow_root_created_by_task": workflow_root_created_by_task,
+            "protected_tmp_root": str(protected_tmp_root),
+        }
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    summary["created_files"] = cleanup_order
+    print(json.dumps(summary, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

为 Skill 补齐「PDF 固定预处理 → created_files.json 驱动的任务级临时清理」闭环，把 PDF 处理从"每次临时写解析脚本"固化为 Skill 自带脚本 + 标准化清理协议。任务收尾后 `<vault>/tmp/` 只留本次工作流痕迹，最佳状态下 `tmp/obsidian-llm-wiki/` 容器因空而被删除。

## 变更清单

### 新增 `scripts/preprocess_pdf.py`

- CLI：`--input <PDF 绝对路径> --vault-root <知识库根> --task-id <时间戳-安全任务标识>`；task-id 白名单校验 + 路径逃逸校验；任务根 `<vault>/tmp/obsidian-llm-wiki/<task-id>/` 运行前必须不存在（拒绝覆盖）。
- 双提取器：pypdf 优先中文文本与元数据；PyMuPDF 负责页数、嵌入图片对象、xref 与整页渲染。逐页质量判定（替换字符 ≤1%、控制字符 ≤0.5%、无连续乱码），pypdf 不合格且 PyMuPDF 更优时逐页降级；两者都不合格自动渲染 2x PNG 并标记 `requires_visual`，绝不把乱码当正文。
- 固定产物：`metadata.json` / `pages.json` / `page_text.md` / `image_manifest.csv` / `unique_image_manifest.csv` / `images/` / `rendered_pages/` / `created_files.json`（finally 无条件写入，异常时也可用作清理依据）。
- `created_files.json` 自描述清理清单：`created_files` + `cleanup_order`（清单自身排最后）、`created_directories`（最深优先）、`conditional_cleanup_directory`（容器条件删除）、`protected_tmp_root`（永不删除）、`workflow_root_created_by_task`。
- 脚本只读输入 PDF，不写 `raw/`、`wiki/`、`index.md`、`log.md`。

### 新增 `references/pdf-preprocessing.md`、`references/temp-cleanup.md`

- 预处理协议：固定入口（项目 `.venv` + `PYTHONUTF8=1`）、双提取器分工、五步逐页决策、产物对账要求、视觉读取衔接。
- 清理协议：冻结清单 → 五项逐文件校验 → 逐个单文件删除 → 空目录窄例外（最深优先、逐目录确认空）→ 容器空则条件删除 → 六项结果汇报（生成数/删除数/文件残留/目录残留/任务根状态/容器状态）。权限只来自本次 `created_files.json`，不从"位于 tmp 下"推断；策略阻断时保留空目录作为受控残留并报告，不绕过。

### `SKILL.md`（8 处插桩）

- 文档预处理运行时：PDF 强制「先读 references/pdf-preprocessing.md 再跑固定脚本」，禁止临时另写脚本；补清理触发时机（成功与可控失败均清理，最终回复前完成）。
- 安全规则：新增「任务临时文件自动清理」条款（杂项中转放系统临时目录、任务产物统一放 `<vault>/tmp/obsidian-llm-wiki/<task-id>/`）；目录删除唯一例外指向清理协议。
- ingest / delete 命令与 description 触发词联动。
- 顺带收编两处此前遗留在本地未提交的文档改动（log 追加章节的 PENDING 变量说明段等），已一并纳入本 PR。

### `README.md`

- 新增「PDF 固定预处理与任务临时目录清理」章节（用法、质量判定、产物清单、清理协议、命令守卫免审批建议）。
- 更新文件结构树、限制条件、SKILL.md 关键内容清单。

### `.gitignore`

- 增加 `__pycache__/`。

## 验证

- 真实中文 PDF（5 页）端到端跑通：2616 字文本、0 降级页；`created_files.json` 与实际文件集合程序化核对一致。
- 健壮性：重复 task-id 拒绝覆盖（FileExistsError）、非法 task-id 拒绝（ValueError）；`py_compile` 通过。
- 清理协议实测：登记文件逐个删除 → 任务目录/遗留空骨架最深优先逐目录删除 → 容器空后条件删除，六项指标全部归零，`<vault>/tmp/` 保留、其他工作流目录未动。
- 与已合并的 #6（日志预检与分卷轮转）无文件冲突，基于最新 main。

## 隐私处理

- 全部新增内容使用 `<vault-root>`、`<skill_base>`、`%TEMP%`、`<用户名>` 等通用占位；已扫描确认不含本地用户名、机器路径或任何密钥形态字符串。
